### PR TITLE
fix: suppress errors when fetching sticky

### DIFF
--- a/src/config/ResponseText.ts
+++ b/src/config/ResponseText.ts
@@ -30,4 +30,4 @@ export enum ResponseText {
 /**
  * This is separate so that the environment value can be interpolated.
  */
-export const StickyMessage = `A friendly reminder to everyone that questions should be asked in <#${process.env.HELP_CHANNEL_ID}>.`;
+export const StickyMessage = `We welcome discussions in this channel, but for technical help, please use <#${process.env.HELP_CHANNEL_ID}>.`;

--- a/src/modules/sendStickyMessage.ts
+++ b/src/modules/sendStickyMessage.ts
@@ -11,10 +11,12 @@ import { errorHandler } from "../utils/errorHandler";
 export const sendStickyMessage = async (bot: ExtendedClient) => {
   try {
     const lastMessage = (
-      await bot.cache.generalChannel.messages.fetch({
-        limit: 1,
-      })
-    ).first();
+      await bot.cache.generalChannel.messages
+        .fetch({
+          limit: 1,
+        })
+        .catch(() => null)
+    )?.first();
     if (!lastMessage) {
       return;
     }
@@ -24,9 +26,9 @@ export const sendStickyMessage = async (bot: ExtendedClient) => {
     }
 
     if (bot.cache.lastSticky) {
-      const lastSticky = await bot.cache.generalChannel.messages.fetch(
-        bot.cache.lastSticky
-      );
+      const lastSticky = await bot.cache.generalChannel.messages
+        .fetch(bot.cache.lastSticky)
+        .catch(() => null);
       if (lastSticky) {
         await lastSticky.delete();
       }


### PR DESCRIPTION
We don't need to care if the sticky message got deleted some other way. As such, failing to fetch the message should not bubble up and block the process. So we can swallow those errors and proceed with the rest of the logic.
